### PR TITLE
Use the config file specified on command line

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ if (!markdownFile) {
   process.exit(1);
 }
 
-const { options, plugins } = loadOptions();
+const { options, plugins } = loadOptions(program.config);
 const md = new MarkdownIt(options);
 plugins.forEach(plugin => {
   let package;


### PR DESCRIPTION
The command line option was specified but unused, so the tool would always look for `.markdownitrc.json`